### PR TITLE
Fix the example provided in README to compile and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ rdns_regress_callback (struct rdns_reply *reply, void *arg)
 static void
 rdns_test_a (struct rdns_resolver *resolver)
 {
-	const char *names[] = {
+	char *names[] = {
 			"google.com",
 			"github.com",
 			"freebsd.org",
@@ -59,26 +59,31 @@ rdns_test_a (struct rdns_resolver *resolver)
 			"www.ник.рф",
 			NULL
 	};
-	const char **cur;
+	char **cur;
 
 	for (cur = names; *cur != NULL; cur ++) {
-		rdns_make_request_full (resolver, rdns_regress_callback, *cur, 1.0, 2, *cur, 1, DNS_REQUEST_A);
+		rdns_make_request_full (resolver, rdns_regress_callback, *cur, 1.0, 2, 1, *cur, RDNS_REQUEST_A);
 		remain_tests ++;
 	}
 }
 
-int main(int argc, char **argv) 
+int
+main(int argc, char **argv)
 {
 	struct rdns_resolver *resolver_ev;
 	struct ev_loop *loop;
-	
+
+	loop = ev_default_loop (0);
+	resolver_ev = rdns_resolver_new ();
+	rdns_bind_libev (resolver_ev, loop);
+
 	rdns_resolver_add_server (resolver_ev, argv[1], strtoul (argv[2], NULL, 10), 0, 8);
 
 	rdns_resolver_init (resolver_ev);
 
 	rdns_test_a (resolver_ev);
 	ev_loop (loop, 0);
-	
+
 	return 0;
 }
 ~~~


### PR DESCRIPTION
I've tested the patched example this way:
- building librdns

```
% mkdir build && cd build && cmake .. && make
```
- building the example from README

```
% vim test.c
% cc -g -c -I /usr/local/include -I ../include test.c
% cc -g test.o librdns_static.a -L /usr/local/lib -lev
```
- Finally launching the test:

```
% ./a.out ::1 53      
got result for host: google.com
got result for host: github.com
got result for host: www.ник.рф
got result for host: kernel.org
got result for host: freebsd.org
%
```

For info:

```
% uname -a
FreeBSD kaworu.ch 10.0-RELEASE-p9 FreeBSD 10.0-RELEASE-p9 #0: Mon Sep 15 14:35:52 UTC 2014     root@amd64-builder.daemonology.net:/usr/obj/usr/src/sys/GENERIC  amd64
% cc --version
FreeBSD clang version 3.3 (tags/RELEASE_33/final 183502) 20130610
Target: x86_64-unknown-freebsd10.0
Thread model: posix
```
